### PR TITLE
fix(error): OutOfMemoryError: unable to create new native thread

### DIFF
--- a/src/main/java/br/com/finalcraft/evernifecore/config/Config.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/config/Config.java
@@ -271,7 +271,7 @@ public class Config {
      * and ensure it's called async
      */
     public void saveAsync() {
-        CfgExecutor.getExecutorService().submit(() -> this.save());
+        CfgExecutor.getExecutorService().execute(() -> this.save());
     }
 
     /**

--- a/src/main/java/br/com/finalcraft/evernifecore/config/playerdata/PlayerController.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/config/playerdata/PlayerController.java
@@ -104,15 +104,18 @@ public class PlayerController {
 
         Queue<PlayerData> loadedPlayerData = new ConcurrentLinkedQueue<>();
 
-        ExecutorService executor = Executors.newFixedThreadPool(Math.min(10, Math.max(playerdataLoader.size(), 1)));
+        ExecutorService executor = Executors.newFixedThreadPool(Math.min(playerdataLoader.size(), Math.max(4, Runtime.getRuntime().availableProcessors())));
         CountDownLatch latch = new CountDownLatch(playerdataLoader.size());
         for (Supplier<PlayerData> supplier : playerdataLoader) {
-            executor.submit(() -> {
-                PlayerData playerData = supplier.get();
-                if (playerData != null){ //Can be null when there is an error loading the PlayerData of the loading was ignored
-                    loadedPlayerData.add(playerData);
+            executor.execute(() -> {
+                try {
+                    PlayerData playerData = supplier.get();
+                    if (playerData != null){ //Can be null when there is an error loading the PlayerData of the loading was ignored
+                        loadedPlayerData.add(playerData);
+                    }
+                } finally {
+                    latch.countDown();
                 }
-                latch.countDown();
             });
         }
 

--- a/src/main/java/br/com/finalcraft/evernifecore/config/yaml/helper/CfgExecutor.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/config/yaml/helper/CfgExecutor.java
@@ -9,13 +9,11 @@ public class CfgExecutor {
 
     private static final Logger logger = Logger.getLogger("CfgExecutor");
 
-    private static final ThreadPoolExecutor scheduler;
+    private static final ScheduledThreadPoolExecutor scheduler;
     public static final ExecutorService EXECUTOR_SERVICE;
 
     static {
-        scheduler = new ThreadPoolExecutor(5, Math.min(5, Runtime.getRuntime().availableProcessors()),
-                1000L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(),
+        scheduler = new ScheduledThreadPoolExecutor(Math.max(5, Runtime.getRuntime().availableProcessors()),
                 new ThreadFactoryBuilder()
                         .setNameFormat("evernifecore-cfgexecutor-caching-%d")
                         .setDaemon(true)
@@ -32,7 +30,7 @@ public class CfgExecutor {
         );
     }
 
-    public static ThreadPoolExecutor getScheduler() {
+    public static ScheduledThreadPoolExecutor getScheduler() {
         return scheduler;
     }
 

--- a/src/main/java/br/com/finalcraft/evernifecore/config/yaml/helper/CfgExecutor.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/config/yaml/helper/CfgExecutor.java
@@ -20,7 +20,7 @@ public class CfgExecutor {
                         .build()
         );
 
-        EXECUTOR_SERVICE = new ThreadPoolExecutor(5, Math.min(5, Runtime.getRuntime().availableProcessors()),
+        EXECUTOR_SERVICE = new ThreadPoolExecutor(5, Math.max(5, Runtime.getRuntime().availableProcessors()),
                 1000L, TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(),
                 new ThreadFactoryBuilder()

--- a/src/main/java/br/com/finalcraft/evernifecore/dependencies/DependencyManager.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/dependencies/DependencyManager.java
@@ -12,10 +12,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.logging.Logger;
 
 public class DependencyManager extends LibraryManager {
@@ -65,9 +62,7 @@ public class DependencyManager extends LibraryManager {
 
         CountDownLatch latch = new CountDownLatch(libraries.size());
 
-        final ThreadPoolExecutor scheduler = new ThreadPoolExecutor(libraries.size() >= 4 ? 4 : libraries.size(), Integer.MAX_VALUE,
-                0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue(),
+        final ExecutorService scheduler = Executors.newFixedThreadPool(Math.min(libraries.size(), Runtime.getRuntime().availableProcessors()),
                 new ThreadFactoryBuilder()
                         .setNameFormat("evernifecore-dependencymanager-pool-%d")
                         .setDaemon(true)
@@ -75,7 +70,7 @@ public class DependencyManager extends LibraryManager {
         );
 
         for (Library library : libraries) {
-            scheduler.submit(() -> {
+            scheduler.execute(() -> {
                 try {
                     this.loadLibrary(library);
                 } catch (Throwable e) {

--- a/src/main/java/br/com/finalcraft/evernifecore/scheduler/FCScheduler.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/scheduler/FCScheduler.java
@@ -9,15 +9,18 @@ import java.util.concurrent.*;
 
 public class FCScheduler {
 
-    private static final ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(
-            9999, //If this goes UP too high, it means the Programmer is faulty here!
+    private static final ThreadPoolExecutor scheduler = new ThreadPoolExecutor(
+            5,
+            Math.min(5, Runtime.getRuntime().availableProcessors()),
+            1000L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
             new ThreadFactoryBuilder()
                     .setNameFormat("evernifecore-fcscheduler-%d")
                     .setDaemon(true)
                     .build()
     );
 
-    public static ScheduledThreadPoolExecutor getScheduler() {
+    public static ThreadPoolExecutor getScheduler() {
         return scheduler;
     }
 
@@ -57,7 +60,7 @@ public class FCScheduler {
     // -----------------------------------------------------------------------------------------------------------------
 
     public static void runAsync(Runnable runnable){
-        scheduler.submit(() -> {
+        scheduler.execute(() -> {
             try {
                 runnable.run();
             }catch (Throwable throwable){

--- a/src/main/java/br/com/finalcraft/evernifecore/scheduler/FCScheduler.java
+++ b/src/main/java/br/com/finalcraft/evernifecore/scheduler/FCScheduler.java
@@ -9,18 +9,15 @@ import java.util.concurrent.*;
 
 public class FCScheduler {
 
-    private static final ThreadPoolExecutor scheduler = new ThreadPoolExecutor(
-            5,
-            Math.min(5, Runtime.getRuntime().availableProcessors()),
-            1000L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(),
+    private static final ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(
+            Math.max(5, Runtime.getRuntime().availableProcessors()),
             new ThreadFactoryBuilder()
                     .setNameFormat("evernifecore-fcscheduler-%d")
                     .setDaemon(true)
                     .build()
     );
 
-    public static ThreadPoolExecutor getScheduler() {
+    public static ScheduledThreadPoolExecutor getScheduler() {
         return scheduler;
     }
 


### PR DESCRIPTION
Hi!

After investigation, I found that **the plugin is creating too many threads**, causing the error "OutOfMemoryError: unable to create new native thread".

```
[...]

jdk.ThreadStart {
  startTime = 02:56:37.944
  thread = "pool-83-thread-3720" (javaThreadId = 4053)
  parentThread = "pool-82-thread-4" (javaThreadId = 326)
  eventThread = "pool-83-thread-3720" (javaThreadId = 4053)
  stackTrace = [
    java.util.concurrent.ThreadPoolExecutor.addWorker(Runnable, boolean) line: 957
    java.util.concurrent.ThreadPoolExecutor.ensurePrestart() line: 1603
    java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(RunnableScheduledFuture) line: 334
    java.util.concurrent.ScheduledThreadPoolExecutor.schedule(Runnable, long, TimeUnit) line: 533
    br.com.finalcraft.evernifecore.config.yaml.caching.SmartCachedYamlFileHolder.scheduleExpirationRunnable(long) line: 65
    ...
  ]
}

jdk.ThreadStart {
  startTime = 02:56:37.945
  thread = "pool-83-thread-3719" (javaThreadId = 4054)
  parentThread = "pool-82-thread-1" (javaThreadId = 323)
  eventThread = "pool-83-thread-3719" (javaThreadId = 4054)
  stackTrace = [
    java.util.concurrent.ThreadPoolExecutor.addWorker(Runnable, boolean) line: 957
    java.util.concurrent.ThreadPoolExecutor.ensurePrestart() line: 1603
    java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(RunnableScheduledFuture) line: 334
    java.util.concurrent.ScheduledThreadPoolExecutor.schedule(Runnable, long, TimeUnit) line: 533
    br.com.finalcraft.evernifecore.config.yaml.caching.SmartCachedYamlFileHolder.scheduleExpirationRunnable(long) line: 65
    ...
  ]
}

jdk.ThreadStart {
  startTime = 02:56:37.945
  thread = "pool-83-thread-3718" (javaThreadId = 4055)
  parentThread = "pool-82-thread-10" (javaThreadId = 332)
  eventThread = "pool-83-thread-3718" (javaThreadId = 4055)
  stackTrace = [
    java.util.concurrent.ThreadPoolExecutor.addWorker(Runnable, boolean) line: 957
    java.util.concurrent.ThreadPoolExecutor.ensurePrestart() line: 1603
    java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(RunnableScheduledFuture) line: 334
    java.util.concurrent.ScheduledThreadPoolExecutor.schedule(Runnable, long, TimeUnit) line: 533
    br.com.finalcraft.evernifecore.config.yaml.caching.SmartCachedYamlFileHolder.scheduleExpirationRunnable(long) line: 65
    ...
  ]
}

jdk.ThreadStart {
  startTime = 02:56:37.945
  thread = "pool-83-thread-3724" (javaThreadId = 4056)
  parentThread = "pool-82-thread-3" (javaThreadId = 325)
  eventThread = "pool-83-thread-3724" (javaThreadId = 4056)
  stackTrace = [
    java.util.concurrent.ThreadPoolExecutor.addWorker(Runnable, boolean) line: 957
    java.util.concurrent.ThreadPoolExecutor.ensurePrestart() line: 1603
    java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(RunnableScheduledFuture) line: 334
    java.util.concurrent.ScheduledThreadPoolExecutor.schedule(Runnable, long, TimeUnit) line: 533
    br.com.finalcraft.evernifecore.config.yaml.caching.SmartCachedYamlFileHolder.scheduleExpirationRunnable(long) line: 65
    ...
  ]
}
```

If the server is running in a Docker container (Pterodactyl for example), the error may be thrown.

This commit limits the number of threads created and prevents the PID limit from being reached.
